### PR TITLE
allow the response to be emtpy

### DIFF
--- a/src/request_maker.rs
+++ b/src/request_maker.rs
@@ -183,10 +183,15 @@ impl RequestMaker {
             replies.append(&mut reply);
         }
 
-        match &replies[0].ret_msg {
-            Some(msg) => return Err(format!("GetMatchDetails Request Error: {}", msg)),
-            None => {}
-        };
+        // allow the response to be empty
+        // this may happen because too many matches were played in the q that day
+        // should probably update this to detect that and get it hourly
+        if replies.len() > 0 {
+            match &replies[0].ret_msg {
+                Some(msg) => return Err(format!("GetMatchDetails Request Error: {}", msg)),
+                None => {}
+            };
+        }
 
         Ok(replies)
     }


### PR DESCRIPTION
This is probably happening because too many ids would be returned, I'll need to tune this for detection and proper resolution later (probably just try getting hourly)